### PR TITLE
Fix for Incorrect URL of Transferable Objects for MDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ More examples: https://github.com/alewin/useWorker/tree/develop/example
 - [x] Reactive web worker status
 - [x] Add timeout option
 - [x] Import and use remote script inside `useWorker` function
-- [x] support [Transferable Objects](https://developer.mozilla.org/en-US/docs/Web/API/Transferable)
+- [x] support [Transferable Objects](https://developer.mozilla.org/en-US/docs/Glossary/Transferable_objects)
 - [x] Testing useWorker [#41](https://github.com/alewin/useWorker/issues/41)
 - [x] Import and use local script inside `useWorker` function [#37](https://github.com/alewin/useWorker/issues/37)
 - [ ] useWorkers Hook [#38](https://github.com/alewin/useWorker/issues/38)

--- a/packages/website/docs/useworker.md
+++ b/packages/website/docs/useworker.md
@@ -45,7 +45,7 @@ to view the values of `WORKER_STATUS` click here: [Status API](./workerstatus.md
 | remoteDependencies | Array of String | []        | An array that contains the remote dependencies needed to run the worker   |
 <!-- | localDependencies  | Function of Array of String | () => []        | A function that returns an array that contains the local dependencies needed to run the worker   | -->
 | autoTerminate      | Boolean         | true      | Kill the worker once it's done (success or error)                         |
-| transferable       | String          | 'auto'    | Enable [Transferable Objects](https://developer.mozilla.org/en-US/docs/Web/API/Transferable), to disable it set transferable: 'none' |
+| transferable       | String          | 'auto'    | Enable [Transferable Objects](https://developer.mozilla.org/en-US/docs/Glossary/Transferable_objects), to disable it set transferable: 'none' |
 
 ## Options Example
 


### PR DESCRIPTION
Fix for the issue reported here: https://github.com/alewin/useWorker/issues/120
